### PR TITLE
Fixed issue where country map and state maps where rendering multiple…

### DIFF
--- a/capstone-ui/src/Components/InteractiveMap/InteractiveMap.jsx
+++ b/capstone-ui/src/Components/InteractiveMap/InteractiveMap.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React, { useEffect, useRef } from 'react';
 import * as topojson from 'topojson-client';
 import usData from '../../data/us.json';
 import "./InteractiveMap.css";
@@ -59,39 +59,46 @@ export default function InteractiveMap({ raceType }) {
         '56': 'wyoming',
       };
 
+      const mapRef = useRef(null);
 
-
-    useEffect(() => {
+      useEffect(() => {
         const margin = { top: 50, left: 50, right: 50, bottom: 50 };
         const height = 400 - margin.top - margin.bottom;
         const width = 800 - margin.left - margin.right;
-
-        const svg = d3
-        .select('#map')
-        .append('svg')
-        .attr('height', height + margin.top + margin.bottom)
-        .attr('width', width + margin.left + margin.right)
-        .append('g')
-        .attr('transform', `translate(${margin.left}, ${margin.top})`);
-
+    
+        const mapContainer = d3.select(mapRef.current);
+    
+        mapContainer.selectAll('svg').remove();
+    
+        const svg = mapContainer
+          .append('svg')
+          .attr('height', height + margin.top + margin.bottom)
+          .attr('width', width + margin.left + margin.right)
+          .append('g')
+          .attr('transform', `translate(${margin.left}, ${margin.top})`);
+    
         const projection = d3.geoAlbersUsa().translate([width / 2, height / 2]).scale(800);
 
         const path = d3.geoPath().projection(projection);
 
         const states = topojson.feature(usData, usData.objects.states).features;
-
+    
         svg.selectAll('.state')
-        .data(states)
-        .enter().append('path')
-        .attr('class', 'state')
-        .attr('d', path)
-        .on('click', function(d) {
+          .data(states)
+          .enter().append('path')
+          .attr('class', 'state')
+          .attr('d', path)
+          .on('click', function(d) {
             const stateName = fipsStateCodes[d.id];
             window.location.href = `/${raceType}/${stateName}`;
-        });
-    }, []);
+          });
+    
+        return () => {
+          svg.remove();
+        };
+      }, []);
 
     return (
-        <div id="map"></div>
+        <div ref={mapRef} className="interactive-map-container"></div>
         )
 }


### PR DESCRIPTION
… times due to the useEffect in the maps being triggered multiple times.

@nick-r-117 @amt040 @Ruian-Li

Description:
This issue involved the useEffect hook being triggered multiple times, leading to the duplication of map renderings even though the dependency array was empty in the useEffects. This is from the stackoverflow link in the resources below and I think it's what's causing the map to render twice:

> This new check will automatically unmount and remount every component, whenever a component mounts for the first time, restoring the previous state on the second mount.

I believe the unmounting and remounting was causing the useEffect hook to be triggered more than once when the page initially loads up. 

I addressed this by implementing a cleanup function inside the useEffect to remove the svg element when the component was unmounted. This is what makes sure that the maps won't be duplicated during any mounting or unmounting. I also introduced a useRef called mapRef to hold a reference to the map container element in both InteractiveMap and StateMap components so that each map component has it's own unique container.

Milestones:
- User can compare candidates from federal races
- User can see election results for every state/district for past elections

Resources:
https://dmitripavlutin.com/react-useref/
https://stackoverflow.com/questions/62631053/useeffect-being-called-multiple-times

Test Details:
<img width="1509" alt="image" src="https://github.com/carlosm4247/capstone-project/assets/126618515/9904e6af-b21a-4726-ae5e-9ff8e4e3d222">
<img width="1509" alt="image" src="https://github.com/carlosm4247/capstone-project/assets/126618515/06c4df20-7f80-472c-b5b0-407cd573d867">
