### PR TITLE
ResultsBox now starts with maximum 5 candidates and allows the user to show the rest if there are more.

### DIFF
--- a/capstone-ui/src/Components/ResultsBox/ResultsBox.jsx
+++ b/capstone-ui/src/Components/ResultsBox/ResultsBox.jsx
@@ -10,6 +10,8 @@ export default function ResultsBox( { locationLevel, countyFIPS, selectedCandida
     let data = []
     let candidates = []
     const { stateName } = useParams();
+    const initialCandidates = 5;
+    const [candidatesShowing, setCandidatesShowing] = useState(initialCandidates);
 
     function addCandidate(key, name, voteCount, percentage) {
         let candidate = {
@@ -85,7 +87,7 @@ export default function ResultsBox( { locationLevel, countyFIPS, selectedCandida
               </tr>
             </thead>
             <tbody>
-              {candidates.map((candidate) => (
+              {candidates.slice(0, candidatesShowing).map((candidate) => (
                 <tr key={candidate.key}
                     onClick={() => handleClick(candidate.key, candidate.name)}
                     className={ (selectedCandidates && (selectedCandidates.some((c) => c.key === candidate.key))) ? "selected" : ""}
@@ -97,6 +99,11 @@ export default function ResultsBox( { locationLevel, countyFIPS, selectedCandida
               ))}
             </tbody>
           </table>
+          {locationLevel != 3 && candidatesShowing < candidates.length && (
+            <button onClick={() => setCandidatesShowing((prev) => prev + initialCandidates)}>
+              Show More
+            </button>
+          )}
         </div>
     )
 }


### PR DESCRIPTION
Description:
If there are more than 5 candidates in any particular page on initial load of the ResultsBox, the component will hold it at 5 using the slice method. For the states and country, if the user clicks the show more button, it will add the rest of the candidates. For counties, there's no button displayed because those results appear on hover and the user has no use for it.

Milestones:
- User can compare candidates from federal races
- User can follow candidates/races and get news on them in a feed

Test Details:

https://github.com/carlosm4247/capstone-project/assets/126618515/31edfb5d-2bb5-42f2-8a92-8093d730d8bc

