### PR TITLE
Adding stances to users and allowing users to fill in stances on sign up

### DIFF
--- a/capstone-api/models/users.js
+++ b/capstone-api/models/users.js
@@ -19,6 +19,11 @@ export const User = sequelize.define("User", {
         type: DataTypes.ARRAY(DataTypes.STRING),
         allowNull: false,
         defaultValue: []
+    },
+    stances: {
+        type: DataTypes.JSON,
+        allowNull: false,
+        defaultValue: {},
     }
 
 })

--- a/capstone-api/routes/users.js
+++ b/capstone-api/routes/users.js
@@ -5,7 +5,7 @@ import { User } from "../models/users.js";
 const router = express.Router();
 
 router.post("/users", async (req, res) => {
-    const { username, password, zipcode } = req.body;
+    const { username, password, zipcode, stances } = req.body;
 
     try {
         const existingUser = await User.findOne({ where:{ username } });
@@ -16,7 +16,7 @@ router.post("/users", async (req, res) => {
 
         const hashedPassword = await bcrypt.hash(password, 10);
 
-        const newUser = await User.create({ username, password: hashedPassword, zipcode });
+        const newUser = await User.create({ username, password: hashedPassword, zipcode, stances });
 
         req.session.user = newUser;
 

--- a/capstone-ui/src/Components/SignupForm/SignupForm.css
+++ b/capstone-ui/src/Components/SignupForm/SignupForm.css
@@ -7,7 +7,7 @@
 .signup-form {
     display: flex;
     flex-direction: column;
-    width: 300px;
+    width: 400px;
     padding: 20px;
     border: 1px solid #ddd;
     border-radius: 10px;
@@ -24,6 +24,18 @@
     font-weight: bold;
     text-align: left;
     flex: 1;
+}
+
+.signup-form .form-group .stances {
+    flex-direction: column;
+    margin-bottom: 10px;
+}
+
+.signup-form select {
+    padding: 10px;
+    border: 1px solid #ddd;
+    border-radius: 5px;
+    width: 100%;
 }
 
 .signup-form input {

--- a/capstone-ui/src/Components/SignupForm/SignupForm.jsx
+++ b/capstone-ui/src/Components/SignupForm/SignupForm.jsx
@@ -1,14 +1,16 @@
 import React, { useState, useContext } from "react";
 import { Link, useNavigate } from "react-router-dom";
 import { UserContext } from "../../UserContext";
+import { questionsWithOptions } from "../../constants";
 import "./SignupForm.css";
 
 const SignupForm = () => {
     const [username, setUsername] = useState("");
     const [password, setPassword] = useState("");
     const [zipcode, setZipcode] = useState("");
-    const { updateUser } = useContext(UserContext);
+    const [stances, setStances] = useState({})
 
+    const { updateUser } = useContext(UserContext);
     const navigate = useNavigate();
 
     const isValidZip = (zip) => {
@@ -29,7 +31,7 @@ const SignupForm = () => {
                 headers: {
                     "Content-Type": "application/json",
                 },
-                body: JSON.stringify({ username, password, zipcode }),
+                body: JSON.stringify({ username, password, zipcode, stances }),
                 credentials: "include"
             });
 
@@ -40,6 +42,7 @@ const SignupForm = () => {
                 setUsername("");
                 setPassword("");
                 setZipcode("");
+                setStances({})
 
                 updateUser(loggedInUser);
 
@@ -90,6 +93,29 @@ const SignupForm = () => {
                         required 
                     />
                 </div>
+                <h3>Stances</h3>
+                {Object.entries(questionsWithOptions).map(([question, options]) => (
+                <div className="form-group" key={question}>
+                    <div className="stances">
+                        <label htmlFor={question}>{question}</label>
+                        <select
+                            id={question}
+                            value={stances[question] || ""}
+                            onChange={(e) =>
+                                setStances({ ...stances, [question]: e.target.value })
+                            }
+                            required
+                        >
+                        <option value="">Select your stance</option>
+                        {options.map((option, index) => (
+                            <option key={index} value={option}>
+                            {option}
+                            </option>
+                        ))}
+                        </select>
+                    </div>
+                </div>
+                ))}
                 <button type="submit">Sign Up</button>
                 <p>Already have an account? <Link to="/login">Login</Link></p>
             </form>

--- a/capstone-ui/src/constants.js
+++ b/capstone-ui/src/constants.js
@@ -5,4 +5,100 @@ const options = [
 
 const unclickables = ["Independent", "Write-ins", "None of these candidates"];
 
-export { options, unclickables };
+const questionsWithOptions = {
+  "What is your stance on abortion?": [
+    "Pro-life, and I also oppose abortion for victims of rape and incest",
+    "Pro-life, but allow in cases of rape, incest, or danger to the mother or child",
+    "Pro-choice, but ban after the first three months",
+    "Pro-choice, I don’t agree but the government has no right to ban it",
+    "Pro-choice, and providing birth control, sex education, and more social services will help reduce the number of abortions"
+  ],
+  "Should convicted criminals have the right to vote?": [
+    "Yes, every citizen deserves the right to vote",
+    "Yes, except for felons convicted of murder or violent crimes",
+    "Yes, but only after completing their sentences and parole/probation",
+    "No"
+  ],
+  "Should funding for local police departments be redirected to social and community-based programs?": [
+    "Yes, and abolish the police",
+    "Yes, replace police with unarmed community-based responders for non-violent calls",
+    "No, increase funding and training for police departments in higher crime rate communities"
+  ],
+  "Should the government increase or decrease military spending?": [
+    "Increase",
+    "Increase, but only after our deficit is drastically reduced",
+    "Neither, I am satisfied with the current amount of spending",
+    "Decrease"
+  ],
+  "Should the federal government increase funding of entitlements, such as Medicaid, Medicare, Social Security, and Unemployment?": [
+    "Yes",
+    "Yes, but only increase for the elderly and disabled",
+    "No, and each state should decide their own level of coverage",
+    "No, and eligibility should only include the elderly and disabled",
+    "No, the federal government should not increase funding for any social programs",
+    "No, and abolish all entitlements"
+  ],
+  "Should the U.S. raise taxes on the rich?": [
+    "Yes",
+    "Yes, but raise taxes on all other income brackets as well",
+    "No, but lower taxes for the poor",
+    "No, keep the current tax structure",
+    "No, reform to a flat tax",
+    "No, lower the income tax rate and remove all existing tax loopholes for large corporations",
+    "No, abolish the income tax, disallow all deductions and increase the sales tax"
+  ],
+  "If found guilty, should former President Trump be pardoned for mishandling classified documents?": [
+    "Yes, he did nothing wrong",
+    "Yes, this indictment represents a political double standard",
+    "No, no one is above the law"
+  ],
+  "Should the government increase environmental regulations to prevent climate change?": [
+    "Yes, and provide more incentives for alternative energy production",
+    "No, provide more incentives for alternative energy production instead",
+    "No, tax carbon emissions instead",
+    "No, global warming is a natural occurrence and there's nothing we can do"
+  ],
+  "Should the government raise the federal minimum wage?": [
+    "Yes, make it a living wage",
+    "Yes, and adjust it every year according to inflation",
+    "No",
+    "No, and remove any federal minimum wage"
+  ],
+  "Should there be more restrictions on the current process of purchasing a gun?": [
+    "Yes, all guns should be banned from private citizen ownership.",
+    "Yes, ban all guns except hunting rifles",
+    "Yes, ban assault rifles",
+    "Yes, require more stringent background checks, training, and add more psychological testing.",
+    "No, current laws are already sufficient",
+    "No, except to expand to individuals with mental health issues.",
+    "No, the government should not infringe on the second amendment.",
+    "No, a citizen has the right to bear arms in private and public."
+  ],
+  "Should the federal government pay for tuition at four-year colleges and universities?": [
+    "Yes",
+    "Yes, but only for partial tuition",
+    "No, but provide lower interest rates for student loans",
+    "No, but provide more scholarship opportunities for low-income students",
+    "No"
+  ],
+  "Do you support affirmative action programs?": [
+    "Yes, but it's only a band-aid trying to heal a much larger issue and we should create more social programs to address poverty",
+    "Yes",
+    "No, and minority groups should not receive any favorable treatment"
+  ],
+  "Should the U.S. build a wall along the southern border?": [
+    "Yes, and Mexico should pay for it",
+    "Yes",
+    "No, but increase our military presence along the southern border",
+    "No, this would be too costly and ineffective"
+  ],
+  "Do you support the Affordable Care Act (Obamacare)?": [
+    "Yes, but a mandatory single-payer system would be even better",
+    "Yes",
+    "Yes, I support a majority of the plan but not all aspects",
+    "No, government should not be involved in healthcare",
+    "No, open the markets so insurers can compete across state lines"
+  ]
+};
+
+export { options, unclickables, questionsWithOptions };


### PR DESCRIPTION
Description:
- Implemented a model for the stances dictionary as a part of the User, and integrated it with the user database. 
- Added a dictionary containing questions and options for stances to the constants file. This way, it can be easily accessed anywhere I need it.
- A new section has been added to the signup page, specifically designed for users to fill in their stances based on the questions and options provided in the questionsWithOptions dictionary. When users submit their responses, they are routed to /users, where their stance data is stored in the user database.
- Added styling so that the questions and select boxes are now aligned in columns instead of rows below the other sign up entries, ensuring that they fit within the signup box.

Milestones:
- User can follow candidates/races and get news on them in a feed

Test Details:
<img width="1512" alt="image" src="https://github.com/carlosm4247/capstone-project/assets/126618515/c9a699f8-365d-4948-bcbd-472c638e622b">

<img width="1512" alt="image" src="https://github.com/carlosm4247/capstone-project/assets/126618515/b391737b-975d-4725-92d2-5175813cb417">
