### PR TITLE
Basic feed when not logged in

### DIFF
--- a/capstone-api/routes/feed.js
+++ b/capstone-api/routes/feed.js
@@ -30,8 +30,6 @@ router.get("/news", async (req, res) => {
 
     const params = { ...baseParams, q: constructedQuery };
 
-    console.log(params)
-
     const response = await axios.get(apiUrl, {
         params,
         headers: {

--- a/capstone-api/routes/feed.js
+++ b/capstone-api/routes/feed.js
@@ -1,0 +1,50 @@
+import express from "express";
+import axios from "axios";
+
+const router = express.Router();
+
+router.get("/news", async (req, res) => {
+
+  const { query, loggedIn } = req.query;
+  let constructedQuery = ""
+
+  try {
+    const apiKey = "gJt8QAwXGc_mzm8Nc9Gvj975ZSnKD-A9Pr2oBIkr9g4";
+    const apiUrl = "https://api.newscatcherapi.com/v2/search";
+
+    const baseParams = {
+        lang: "en", 
+        countries: "US", 
+        topic: "politics",
+        sources: "foxnews.com,wsj.com,nytimes.com,cnn.com,npr.org,washingtonpost.com,apnews.com,msnbc.com",
+        sort_by: "date",
+        page_size: 20
+    };
+
+    if (loggedIn === "true") {
+        constructedQuery = query.length > 0 ? `(${query.join(" OR ")})` : "politics";
+    } 
+    else {
+        constructedQuery = "politics";
+    }
+
+    const params = { ...baseParams, q: constructedQuery };
+
+    console.log(params)
+
+    const response = await axios.get(apiUrl, {
+        params,
+        headers: {
+          "x-api-key": apiKey,
+        },
+    });
+
+    const articles = response.data.articles;
+    res.json({ articles });
+  } catch (error) {
+    console.error(error);
+    res.status(500).json({ error: "Server error" });
+  }
+});
+
+export default router;

--- a/capstone-api/server.js
+++ b/capstone-api/server.js
@@ -5,6 +5,7 @@ import morgan from "morgan";
 import { sequelize } from "./database.js";
 import { User } from "./models/users.js";
 import userRoutes from "./routes/users.js";
+import feedRoute from "./routes/feed.js"
 import SequelizeStoreInit from "connect-session-sequelize";
 
 const app = express();
@@ -37,6 +38,7 @@ app.use(
 
 sessionStore.sync();
 
+app.use(feedRoute);
 app.use(userRoutes);
 
 sequelize.sync({ alter: true })

--- a/capstone-ui/src/Components/Feed/Feed.jsx
+++ b/capstone-ui/src/Components/Feed/Feed.jsx
@@ -1,15 +1,44 @@
-import React from "react";
+import React, { useState, useEffect } from "react";
 import "./Feed.css"
 
 export default function Feed ( { loggedin }) {
 
+    const [articles, setArticles] = useState([]);
+    const [searchQuery, setSearchQuery] = useState([]);
+
+    useEffect(() => {
+        const fetchNewsArticles = async () => {
+          try {
+            const url = `http://localhost:3001/news?query=${JSON.stringify(searchQuery)}&loggedIn=${loggedin}`;
+    
+            const response = await fetch(url, {
+                method: "GET",
+                credentials: "include",
+            });
+
+            const data = await response.json();
+    
+            setArticles(data.articles);
+          } catch (error) {
+            console.error(error);
+          }
+        };
+    
+        fetchNewsArticles();
+      }, [searchQuery, loggedin]);
+
     return (
         <div className="feed-container">
-            { loggedin ? (
-                <h3>Logged in Feed</h3>
-            ) : (
-                <h3>Not Logged in Feed</h3>
-            )}
+            <h3>Feed</h3>
+            <ul>
+                {articles.map((article, index) => (
+                <li key={index}>
+                    <a href={article.url} target="_blank">
+                    {article.title}
+                    </a>
+                </li>
+                ))}
+            </ul>
         </div>
     )
 }


### PR DESCRIPTION
Description:
- Created a get route for the news api search. It takes in a query array from the feed which will eventually have the stance tags and candidates followed as an array of strings which will all be added to the search parameters to find articles. It also takes in a loggedIn boolean from the feed which actually checks if the user is logged in. Based on that, it will either use the query array if the user is logged in or just a basic "politics" search if the user is not logged in. Alternatively, it could also do a basic "politics" search if the user is logged in but the query array is empty (no candidates followed or stances) which shouldn't happen but just in case. It will add this to some preset parameters I want for every search and return a json with the articles.
- In the feed component, I added the fetch which sends the query array and loggedin boolean to the /news route to be used for the API request. The searchQuery is what will be eventually filled in with the stances and candidates followed. 
- The articles are gotten by the feed, and from there we can display them in a uniform fashion in the feed component using mapping. 
- Currently, it just has the basic feed with the "politics" search, but will be expanded in the upcoming PRs with the user personalization. It also just has titles right now, the actual full article component will be added on later when the personalized searches are also loading.

Milestones:
User can follow candidates/races and get news on them in a feed

Test Details:
<img width="1512" alt="image" src="https://github.com/carlosm4247/capstone-project/assets/126618515/9c920712-86f6-435d-be55-73cff3328fcf">